### PR TITLE
Fix missing import

### DIFF
--- a/repology/template_helpers.py
+++ b/repology/template_helpers.py
@@ -19,6 +19,7 @@
 
 import flask
 
+from repology.package import PackageVersionClass, RepositoryVersionClass
 from repology.packageformatter import PackageFormatter
 
 


### PR DESCRIPTION
Without this I was getting:

```
 * Running on http://127.0.0.1:5000/ (Press CTRL+C to quit)
[2017-04-30 12:43:46,258] ERROR in app: Exception on /metapackage/010editor/versions [GET]
Traceback (most recent call last):
  File "/repology/venv/lib/python3.6/site-packages/flask/app.py", line 1982, in wsgi_app
    response = self.full_dispatch_request()
  File "/repology/venv/lib/python3.6/site-packages/flask/app.py", line 1614, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/repology/venv/lib/python3.6/site-packages/flask/app.py", line 1517, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/repology/venv/lib/python3.6/site-packages/flask/_compat.py", line 33, in reraise
    raise value
  File "/repology/venv/lib/python3.6/site-packages/flask/app.py", line 1612, in full_dispatch_request
    rv = self.dispatch_request()
  File "/repology/venv/lib/python3.6/site-packages/flask/app.py", line 1598, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "./repology-app.py", line 467, in metapackage_versions
    return flask.render_template('metapackage-versions.html', packages_by_repo=packages_by_repo, name=name)
  File "/repology/venv/lib/python3.6/site-packages/flask/templating.py", line 134, in render_template
    context, ctx.app)
  File "/repology/venv/lib/python3.6/site-packages/flask/templating.py", line 116, in _render
    rv = template.render(context)
  File "/repology/venv/lib/python3.6/site-packages/jinja2/asyncsupport.py", line 76, in render
    return original_render(self, *args, **kwargs)
  File "/repology/venv/lib/python3.6/site-packages/jinja2/environment.py", line 1008, in render
    return self.environment.handle_exception(exc_info, True)
  File "/repology/venv/lib/python3.6/site-packages/jinja2/environment.py", line 780, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "/repology/venv/lib/python3.6/site-packages/jinja2/_compat.py", line 37, in reraise
    raise value.with_traceback(tb)
  File "/repology/checkout/templates/metapackage-versions.html", line 2, in top-level template code
    {% import "macros.html" as macros %}
  File "/repology/checkout/templates/metapackage.html", line 1, in top-level template code
    {% extends "layout.html" %}
  File "/repology/checkout/templates/layout.html", line 75, in top-level template code
    {% block content %}
  File "/repology/checkout/templates/metapackage-versions.html", line 36, in block "content"
    <span class="version version-big version-{{ package.versionclass|css_for_package_versionclass }}">
  File "/repology/checkout/repology/template_helpers.py", line 71, in css_for_package_versionclass
    if value == PackageVersionClass.newest:
NameError: name 'PackageVersionClass' is not defined
10.0.1.154 - - [30/Apr/2017 12:43:46] "GET /metapackage/010editor/versions HTTP/1.1" 500 -
```

