### PR TITLE
Add Slackware repository support (revised & rebased, please re-review).

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ version are always parsed.
 | Ravenports                       | ✔       |         | ✔     | ✔     |         |          |
 | RubyGems                         |         |         |       | ✔ (2) |         |          |
 | SlackBuilds                      |         | ✔       | ✔     | ✔     |         | ✔        |
+| Slackware                        |         | ✔       | ✔     |       |         |          |
 | YACP                             |         |         |       |       |         |          |
 
 (1) Gentoo support is not complete, complex cases like condional downloads and licenses

--- a/repology-schemacheck.py
+++ b/repology-schemacheck.py
@@ -68,6 +68,7 @@ families = [
     'rubygems',
     'sisyphus',
     'slackbuilds',
+    'slackware',
     'snap',
     'yacp',
 ]

--- a/repology/parsers/slackware.py
+++ b/repology/parsers/slackware.py
@@ -1,0 +1,65 @@
+# Copyright (C) 2016 Dmitry Marakasov <amdmi3@amdmi3.ru>
+# Copyright (C) 2017 David Spencer <idlemoor@slackbuilds.org>
+#
+# This file is part of repology
+#
+# repology is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# repology is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with repology.  If not, see <http://www.gnu.org/licenses/>.
+
+import re
+import sys
+
+from repology.package import Package
+
+
+class SlackwareParser():
+    def __init__(self):
+        pass
+
+# pylint: disable=R0201
+    def Parse(self, path):
+        result = []
+
+        # Look for packages in these subrepositories:
+        subrepolist = ['slackware', 'slackware64', 'patches', 'extra']
+        # Everything else is ignored.
+
+        with open(path, 'r') as filelisttxt:
+            for line in filelisttxt.readlines():
+                components = line.strip().split('/')
+                if len(components) < 4:
+                    # ignore lines that are not deep enough in the hierarchy (containing dirs etc)
+                    continue
+                topdir = components[1]
+                if topdir not in subrepolist:
+                    continue
+                basename = components[-1]
+                if re.search('\.t.z$', basename):
+                    parsedbasename = basename.rsplit('-', 3)
+                    if len(parsedbasename) != 4:
+                        print('WARNING: unable to parse package name {}'.format(basename), file=sys.stderr)
+                        continue
+
+                    pkg = Package()
+                    pkg.name = parsedbasename[0]
+                    pkg.version = parsedbasename[1]
+                    pkg.subrepo = topdir
+                    if pkg.subrepo == 'patches' or pkg.subrepo == 'extra':
+                        pkg.category = pkg.subrepo
+                        pkg.extrafields['sourcedir'] = '{}/source/{}'.format(pkg.category, pkg.name)
+                    else:
+                        pkg.category = components[2]
+                        pkg.extrafields['sourcedir'] = 'source/{}/{}'.format(pkg.category, pkg.name)
+                    result.append(pkg)
+
+        return result

--- a/repos.d/slackware.yaml
+++ b/repos.d/slackware.yaml
@@ -1,0 +1,103 @@
+###########################################################################
+# Slackware
+###########################################################################
+
+- name: slackware_14_2
+  type: repository
+  desc: Slackware 14.2
+  family: slackware
+  color: '0066ff'
+  default_maintainer: volkerdi@slackware.com
+  sources:
+    - name: FILELIST-i586.txt
+      fetcher: File
+      parser: Slackware
+      url: http://mirrors.slackware.com/slackware/slackware-14.2/FILELIST.TXT
+    - name: FILELIST-x86_64.txt
+      fetcher: File
+      parser: Slackware
+      url: http://mirrors.slackware.com/slackware/slackware64-14.2/FILELIST.TXT
+  repolinks:
+    - desc: Slackware Home
+      url: http://www.slackware.com/
+    - desc: Slackware x86 (32-bit) 14.2 ChangeLog
+      url: http://mirrors.slackware.com/slackware/slackware-14.2/ChangeLog.txt
+    - desc: Slackware x86_64 14.2 ChangeLog
+      url: http://mirrors.slackware.com/slackware/slackware64-14.2/ChangeLog.txt
+  packagelinks:
+    - desc: Source directory
+      url: 'http://mirrors.slackware.com/slackware/slackware-14.2/{sourcedir}'
+  tags: [ all, production, slackware ]
+
+- name: slackware_current
+  type: repository
+  desc: Slackware Current
+  family: slackware
+  color: '0066ff'
+  default_maintainer: volkerdi@slackware.com
+  sources:
+    - name: FILELIST-i586.txt
+      fetcher: File
+      parser: Slackware
+      url: http://mirrors.slackware.com/slackware/slackware-current/FILELIST.TXT
+    - name: FILELIST-x86_64.txt
+      fetcher: File
+      parser: Slackware
+      url: http://mirrors.slackware.com/slackware/slackware64-current/FILELIST.TXT
+  repolinks:
+    - desc: Slackware Home
+      url: http://www.slackware.com/
+    - desc: Slackware x86 (32-bit) Current ChangeLog
+      url: http://mirrors.slackware.com/slackware/slackware-current/ChangeLog.txt
+    - desc: Slackware x86_64 Current ChangeLog
+      url: http://mirrors.slackware.com/slackware/slackware64-current/ChangeLog.txt
+  packagelinks:
+    - desc: Source directory
+      url: 'http://mirrors.slackware.com/slackware/slackware-current/{sourcedir}'
+  tags: [ all, production, slackware ]
+
+- name: slackwarearm_14_2
+  type: repository
+  desc: SlackwareARM 14.2
+  family: slackware
+  color: '0066ff'
+  default_maintainer: volkerdi@slackware.com
+  sources:
+    - name: FILELIST-arm.txt
+      fetcher: File
+      parser: Slackware
+      url: http://slackware.uk/slackwarearm/slackwarearm-14.2/FILELIST.TXT
+  repolinks:
+    - desc: Slackware Home
+      url: http://www.slackware.com/
+    - desc: Slackware ARM 14.2 ChangeLog
+      url: http://slackware.uk/slackwarearm/slackwarearm-14.2/ChangeLog.txt
+  packagelinks:
+    - desc: Source directory (ARM)
+      url: 'http://slackware.uk/slackwarearm/slackwarearm-14.2/{sourcedir}'
+    - desc: Source directory (base)
+      url: 'http://mirrors.slackware.com/slackware/slackware-14.2/{sourcedir}'
+  tags: [ all, production, slackware ]
+
+- name: slackwarearm_current
+  type: repository
+  desc: SlackwareARM Current
+  family: slackware
+  color: '0066ff'
+  default_maintainer: volkerdi@slackware.com
+  sources:
+    - name: FILELIST-arm.txt
+      fetcher: File
+      parser: Slackware
+      url: http://slackware.uk/slackwarearm/slackwarearm-current/FILELIST.TXT
+  repolinks:
+    - desc: Slackware Home
+      url: http://www.slackware.com/
+    - desc: Slackware ARM Current ChangeLog
+      url: http://slackware.uk/slackwarearm/slackwarearm-current/ChangeLog.txt
+  packagelinks:
+    - desc: Source directory (ARM)
+      url: 'http://slackware.uk/slackwarearm/slackwarearm-current/{sourcedir}'
+    - desc: Source directory (base)
+      url: 'http://mirrors.slackware.com/slackware/slackware-current/{sourcedir}'
+  tags: [ all, production, slackware ]

--- a/rules.d/17.renames-mozilla.yaml
+++ b/rules.d/17.renames-mozilla.yaml
@@ -1,0 +1,2 @@
+- { namepat: mozilla-*firefox(.*), setname: firefox$1 }
+- { namepat: mozilla-*thunderbird(.*), setname: thunderbird$1 }

--- a/rules.d/34.repo-slackware.yaml
+++ b/rules.d/34.repo-slackware.yaml
@@ -1,0 +1,7 @@
+# Don't use a pattern for the gcc-languages, because gcc-java would become java ;)
+- { name: gcc-g++, setname: g++, family: slackware }
+- { name: gcc-brig, setname: brig, family: slackware }
+- { name: gcc-gfortran, setname: gfortran, family: slackware }
+- { name: gcc-gnat, setname: gnat, family: slackware }
+
+- { name: xf86-video-nouveau, category: extra, ignore: true, family: slackware }

--- a/rules.d/50.mergeparts.yaml
+++ b/rules.d/50.mergeparts.yaml
@@ -4,7 +4,7 @@
 - { namepat: "archipel-agent-.*",      setname: "archipel-agents", family: [ debuntu ] }
 - { namepat: "asterisk-core-sounds-.*", setname: "asterisk-core-sounds", family: [ openbsd ] }
 - { namepat: "asterisk-extra-sounds-.*", setname: "asterisk-extra-sounds", family: [ openbsd ] }
-- { namepat: "calligra-l10n-.*",       setname: "calligra-l10n", family: [ sisyphus ] }
+- { namepat: "calligra-l10n-.*",       setname: "calligra-l10n", family: [ sisyphus, slackware ] }
 - { namepat: "eric-i18n-.*",           setname: "eric-i18n" }
 - { namepat: "firefox-kde-i18n-.*",    setname: "firefox-kde-i18n" }
 - { namepat: "firefox-esr-i18n-.*",    setname: "firefox-esr-i18n" }

--- a/rules.d/70.global-python.yaml
+++ b/rules.d/70.global-python.yaml
@@ -5,7 +5,7 @@
 # some rules may merge modules for different python version into single entry; this is intended
 - { namepat: "py[0-9][0-9]-(.*)",      setname: "python:$1", family: [ freebsd, pkgsrc ] }
 - { namepat: "py3?-(.*)",              setname: "python:$1", family: [ openbsd ] }
-- { namepat: "python-(.*)",            setname: "python:$1", family: [ debuntu, centos, mageia, gobolinux, pclinuxos, ravenports ] }
+- { namepat: "python-(.*)",            setname: "python:$1", family: [ debuntu, centos, mageia, gobolinux, pclinuxos, ravenports, slackware ] }
 - { namepat: "python3?-module-(.*)",   setname: "python:$1", family: [ sisyphus ] }
 - { namepat: "python2?-(.*)",          setname: "python:$1", family: [ arch, guix, openmandriva ] }
 #- { namepat: "python2-(.*)",           setname: "python:$1", family: [ msys2 ] }

--- a/rules.d/88.global-fonts.yaml
+++ b/rules.d/88.global-fonts.yaml
@@ -8,6 +8,6 @@
 #  setname: "xfonts:$1"
 - { namepat: "(.*)-fonts",             setname: "fonts:$1", family: [ gentoo ] }
 - { namepat: "(.*)-ttf",               setname: "fonts:$1", family: [ pkgsrc, openindiana ] }
-- { namepat: "font-(.*)",              setname: "fonts:$1", family: [ freebsd, gentoo, pkgsrc, arch, gobolinux, guix, nix, alpine, macports ] }
+- { namepat: "font-(.*)",              setname: "fonts:$1", family: [ freebsd, gentoo, pkgsrc, arch, gobolinux, guix, nix, alpine, macports, slackware ] }
 - { namepat: "fonts-ttf-(.*)",         setname: "fonts:$1", family: [ mageia, rosa ] }
 - { namepat: "fonts-(.*)",             setname: "fonts:$1", family: [ sisyphus ] }


### PR DESCRIPTION
Hi, sorry this has taken so long to revise, I hope this includes all your feedback from pull request #253.

Note that the parser will accept 'slackware' or 'slackware64' or 'slackwarearm' to deal with different directory names in the i586, x86_64 and arm repositories, but only the i586 repositories (with 'slackware') are active in repos.d/slackware.yaml at the moment. 
