### PR TITLE
Allow archive.org/.is for discontinued homepages.

### DIFF
--- a/repology/database.py
+++ b/repology/database.py
@@ -803,10 +803,11 @@ class Database:
                     'Homepage link "' || homepage || '" points to Google Code which was discontinued. The link should be updated (probably along with download URLs). If this link is still alive, it may point to a new project homepage.'
                 FROM packages
                 WHERE
-                    homepage LIKE 'http://%googlecode.com/%' OR
-                    homepage LIKE 'https://%googlecode.com/%' OR
-                    homepage LIKE 'http://code.google.com/%' OR
-                    homepage LIKE 'https://code.google.com/%'
+                    (
+                        homepage SIMILAR TO 'http(s|)://%googlecode.com/%' OR
+                        homepage SIMILAR TO 'http(s|)://code.google.com/%'
+                    ) AND
+                    homepage NOT SIMILAR TO '%(/|.)archive.(org|is)/%'
         """)
 
         self.cursor.execute("""
@@ -820,8 +821,8 @@ class Database:
                     'Homepage link "' || homepage || '" points to codeplex which was discontinued. The link should be updated (probably along with download URLs).'
                 FROM packages
                 WHERE
-                    homepage LIKE 'http://%codeplex.com/%' OR
-                    homepage LIKE 'https://%codeplex.com/%'
+                    homepage SIMILAR TO 'http(s|)://%codeplex.com/%' AND
+                    homepage NOT SIMILAR TO '%(/|.)archive.(org|is)/%'
         """)
 
         self.cursor.execute("""
@@ -835,8 +836,8 @@ class Database:
                     'Homepage link "' || homepage || '" points to Gna which was discontinued. The link should be updated (probably along with download URLs).'
                 FROM packages
                 WHERE
-                    homepage LIKE 'http://%gna.org/%' OR
-                    homepage LIKE 'https://%gna.org/%'
+                    homepage SIMILAR TO 'http(s|)://%gna.org/%' AND
+                    homepage NOT SIMILAR TO '%(/|.)archive.(org|is)/%'
         """)
 
         self.cursor.execute("""


### PR DESCRIPTION
In repology/database.py the discontinued sites googlecode, codeplex and gna are recognised by simple SQL wildcards.  Both archive.org and archive.is have good coverage of googlecode, codeplex and gna. Unfortunately, when the dead homepages are replaced by archive.org, the new url includes the old url, and so the SQL wildcard still matches, and so the new URL is incorrectly listed as a problem.

Example: http://web.archive.org/web/20170206035443/https://gna.org/projects/ngjackspa

This fix simply excludes urls that contain archive.org or archive.is
