### PR TITLE
Recognise openssh-.* as openssh

### DIFF
--- a/rules.d/10.renames-misc.yaml
+++ b/rules.d/10.renames-misc.yaml
@@ -600,6 +600,7 @@
 - { name: opencv2,                     setname: opencv                    }
 - { name: [openjp2, libopenjpeg2.0],   setname: openjpeg2                 }
 - { name: openshot-qt,                 setname: openshot }
+- { name: openssh-.*,                  setname: openssh                   }
 - { name: [openvpn-mbedtls, openvpn-polarssl, openvpn2, openvpn23], setname: openvpn }
 - { name: open-tyrian,                 setname: opentyrian }
 - { name: open-babel,                  setname: openbabel }


### PR DESCRIPTION
Examples:
- openssh-portable on FreeBSD
- openssh-{client-utils,client,keygen,moduli,server-pam,server,sftp-avahi-service,sftp-client,sftp-server} on OpenWRT