### PR TITLE
Complete merging of ravenports uniques (existing issue discovered)

### DIFF
--- a/rules.d/10.renames-misc.yaml
+++ b/rules.d/10.renames-misc.yaml
@@ -795,6 +795,7 @@
 - { name: valyria-tear,                setname: valyriatear               }
 - { name: [varnish4,varnish5],         setname: varnish                   }
 - { name: vdr-devel,                   setname: vdr, ignorever: true      }
+- { name: video4linux,                 setname: v4l-compat                }
 - { name: [vim-console,vim-core,vim-full,vim-gnome,vim-gtk2,vim-gtk3,vim-light,vim-lite,vim-minimal,vim-motif,vim-runtime,vim-share,vim-x11,vim-xaw], setname: vim }
 - { name: vlc-nightly,                 setname: vlc, ignorever: true      }
 - { name: [vlc-qt,vlc-qt4,vlc-qt5,vlc-nox,vlc-decklink], setname: vlc, ignorever: true }

--- a/rules.d/12.renames-fonts.yaml
+++ b/rules.d/12.renames-fonts.yaml
@@ -577,6 +577,8 @@
     - xorg-font-micro-misc
   setname: "fonts:micro-misc"
 
+- { name: xorg-misc-bitmap-fonts, setname: xorg-fonts-miscbitmaps }
+
 - name:
     - montecarlo
     - montecarlo-font
@@ -770,6 +772,8 @@
     - terminus-ttf
     - terminus_ttf
   setname: "fonts:terminus-ttf"
+
+- { name: xorg-truetype-fonts, setname: xorg-fonts-truetype }
 
 # U
 - name:

--- a/rules.d/16.renames-xorg.yaml
+++ b/rules.d/16.renames-xorg.yaml
@@ -16,8 +16,9 @@
 - { namepat: "(?:xorg-|x11-)+(xtrans)-devel", setname: "$1", ignorever: true }
 
 # libs
-- { namepat: "(?:xorg-|x11-)+(?:lib)?(dmx|fontenc|ice|fs|oldx|pciaccess|sm|x11|xau|xaw|xcb|xcomposite|xcursor|xdamage|xdmcp|xevie|xext|xfixes|xfontcache|xft|xi|xinerama|xkbfile|xkbui|xmu|xp|xpm|xrandr|xres|xscrnsaver|xshmfence|xt|xtrans|xtrap|xtst|xv|xvmc|xxf86dga|xxf86misc|xxf86vm)", setname: "lib$1" }
+- { namepat: "(?:xorg-|x11-)+(?:lib)?(dmx|fontenc|ice|fs|oldx|pciaccess|sm|x11|xau|xaw|xcb|xcomposite|xcursor|xdamage|xdmcp|xevie|xext|xfixes|xfontcache|xft|xi|xinerama|xkbfile|xkbui|xmu|xp|xpm|xrandr|xrender|xres|xscrnsaver|xshmfence|xt|xtrans|xtrap|xtst|xv|xvmc|xxf86dga|xxf86misc|xxf86vm)", setname: "lib$1" }
 - { name: [libx32-libxcb,mingw-w64-libxcb,xorg-libxcb], setname: libxcb }
+- { name: [libx32-libxrender,xorg-libxrender,xrender], setname: libxrender }
 
 # libs exceptions
 - { name: [xorg-pixman, xorg-libpixman, libpixman, pixman-static], setname: pixman }

--- a/rules.d/16.renames-xorg.yaml
+++ b/rules.d/16.renames-xorg.yaml
@@ -25,3 +25,7 @@
 
 # libs exceptions
 - { name: [xorg-pixman, xorg-libpixman, libpixman, pixman-static], setname: pixman }
+
+# JRM: font-util was caught by 88.global-fonts.yaml rules, transformed to fonts:util.
+#      It may be more correct to later move them all to "font-util" metapackage
+- { name: [fontutil,font-util,x11-font-util,xorg-font-util,xorg-fontutil], setname: fonts:util }

--- a/rules.d/16.renames-xorg.yaml
+++ b/rules.d/16.renames-xorg.yaml
@@ -14,6 +14,7 @@
 # utils
 - { namepat: "(?:xorg-|x11-)+(bdftopcf|beforelight|editres|mkfontdir|setxkbmap|xauth|xfontsel|xtrans)", setname: "$1" }
 - { namepat: "(?:xorg-|x11-)+(xtrans)-devel", setname: "$1", ignorever: true }
+- { name: xorg-xtransproto, setname: xtrans }
 
 # libs
 - { namepat: "(?:xorg-|x11-)+(?:lib)?(dmx|fontenc|ice|fs|oldx|pciaccess|sm|x11|xau|xaw|xcb|xcomposite|xcursor|xdamage|xdmcp|xevie|xext|xfixes|xfontcache|xft|xi|xinerama|xkbfile|xkbui|xmu|xp|xpm|xrandr|xrender|xres|xscrnsaver|xshmfence|xt|xtrans|xtrap|xtst|xv|xvmc|xxf86dga|xxf86misc|xxf86vm)", setname: "lib$1" }

--- a/rules.d/16.renames-xorg.yaml
+++ b/rules.d/16.renames-xorg.yaml
@@ -6,6 +6,7 @@
 - { name: [xorg-server-xdmx-dev],      setname: xorg-server-xdmx, ignorever: true }
 - { name: [xorg-server-xdmx-mir,xorg-server-xdmx-nosystemd,xorg-server1.12-xdmx], setname: xorg-server-xdmx }
 - { name: [xproxymngproto,xorg-xproxymanagementprotocol,xorg-xproxymngproto], setname: xproxymanagementprotocol }
+- { name: [libxcbutil-proto,mingw-w64-xcb-proto,xorg-xcbproto-devel], setname: xcb-proto }
 - { name: xprintproto, setname: printproto }
 - { namepat: "(?:xorg-)(applewmproto|bigreqsproto|compositeproto|damageproto|dmxproto|dri2proto|dri3proto|evieproto|fixesproto|fontcacheproto|fontsproto|glproto|inputproto|kbproto|presentproto|printproto|randrproto|recordproto|renderproto|resourceproto|scrnsaverproto|trapproto|videoproto|xcmiscproto|xineramaproto|xextproto|xf86bigfontproto|xf86dgaproto|xf86driproto|xf86miscproto|xf86rushproto|xf86vidmodeproto)", setname: "$1" }
 - { namepat: "(?:xorg-)(applewmproto|bigreqsproto|compositeproto|damageproto|dmxproto|dri2proto|dri3proto|evieproto|fixesproto|fontcacheproto|fontsproto|glproto|inputproto|kbproto|presentproto|printproto|randrproto|recordproto|renderproto|resourceproto|scrnsaverproto|trapproto|videoproto|xcmiscproto|xineramaproto|xextproto|xf86bigfontproto|xf86dgaproto|xf86driproto|xf86miscproto|xf86rushproto|xf86vidmodeproto)-devel", setname: "$1", ignorever: true }
@@ -15,7 +16,8 @@
 - { namepat: "(?:xorg-|x11-)+(xtrans)-devel", setname: "$1", ignorever: true }
 
 # libs
-- { namepat: "(?:xorg-|x11-)+(?:lib)?(dmx|fontenc|ice|fs|oldx|pciaccess|sm|x11|xau|xaw|xcomposite|xcursor|xdamage|xdmcp|xevie|xext|xfixes|xfontcache|xft|xi|xinerama|xkbfile|xkbui|xmu|xp|xpm|xrandr|xres|xscrnsaver|xshmfence|xt|xtrans|xtrap|xtst|xv|xvmc|xxf86dga|xxf86misc|xxf86vm)", setname: "lib$1" }
+- { namepat: "(?:xorg-|x11-)+(?:lib)?(dmx|fontenc|ice|fs|oldx|pciaccess|sm|x11|xau|xaw|xcb|xcomposite|xcursor|xdamage|xdmcp|xevie|xext|xfixes|xfontcache|xft|xi|xinerama|xkbfile|xkbui|xmu|xp|xpm|xrandr|xres|xscrnsaver|xshmfence|xt|xtrans|xtrap|xtst|xv|xvmc|xxf86dga|xxf86misc|xxf86vm)", setname: "lib$1" }
+- { name: [libx32-libxcb,mingw-w64-libxcb,xorg-libxcb], setname: libxcb }
 
 # libs exceptions
 - { name: [xorg-pixman, xorg-libpixman, libpixman, pixman-static], setname: pixman }

--- a/rules.d/16.renames-xorg.yaml
+++ b/rules.d/16.renames-xorg.yaml
@@ -12,7 +12,8 @@
 - { namepat: "(?:xorg-)(applewmproto|bigreqsproto|compositeproto|damageproto|dmxproto|dri2proto|dri3proto|evieproto|fixesproto|fontcacheproto|fontsproto|glproto|inputproto|kbproto|presentproto|printproto|randrproto|recordproto|renderproto|resourceproto|scrnsaverproto|trapproto|videoproto|xcmiscproto|xineramaproto|xextproto|xf86bigfontproto|xf86dgaproto|xf86driproto|xf86miscproto|xf86rushproto|xf86vidmodeproto)-devel", setname: "$1", ignorever: true }
 
 # utils
-- { namepat: "(?:xorg-|x11-)+(bdftopcf|beforelight|editres|mkfontdir|setxkbmap|xauth|xfontsel|xtrans)", setname: "$1" }
+- { namepat: "xkeyboard-config-(?:chromebook|hhk|rub)", setname: xkeyboard-config }
+- { namepat: "(?:xorg-|x11-)+(bdftopcf|beforelight|editres|mkfontdir|setxkbmap|xauth|xfontsel|xkeyboard-config|xtrans)", setname: "$1" }
 - { namepat: "(?:xorg-|x11-)+(xtrans)-devel", setname: "$1", ignorever: true }
 - { name: xorg-xtransproto, setname: xtrans }
 

--- a/rules.d/16.renames-xorg.yaml
+++ b/rules.d/16.renames-xorg.yaml
@@ -13,7 +13,7 @@
 
 # utils
 - { namepat: "xkeyboard-config-(?:chromebook|hhk|rub)", setname: xkeyboard-config }
-- { namepat: "(?:xorg-|x11-)+(bdftopcf|beforelight|editres|mkfontdir|setxkbmap|xauth|xfontsel|xkeyboard-config|xtrans)", setname: "$1" }
+- { namepat: "(?:xorg-|x11-)+(bdftopcf|beforelight|editres|mkfontdir|setxkbmap|xauth|xcb-util-renderutil|xfontsel|xkeyboard-config|xtrans)", setname: "$1" }
 - { namepat: "(?:xorg-|x11-)+(xtrans)-devel", setname: "$1", ignorever: true }
 - { name: xorg-xtransproto, setname: xtrans }
 
@@ -21,6 +21,7 @@
 - { namepat: "(?:xorg-|x11-)+(?:lib)?(dmx|fontenc|ice|fs|oldx|pciaccess|sm|x11|xau|xaw|xcb|xcomposite|xcursor|xdamage|xdmcp|xevie|xext|xfixes|xfontcache|xft|xi|xinerama|xkbfile|xkbui|xmu|xp|xpm|xrandr|xrender|xres|xscrnsaver|xshmfence|xt|xtrans|xtrap|xtst|xv|xvmc|xxf86dga|xxf86misc|xxf86vm)", setname: "lib$1" }
 - { name: [libx32-libxcb,mingw-w64-libxcb,xorg-libxcb], setname: libxcb }
 - { name: [libx32-libxrender,xorg-libxrender,xrender], setname: libxrender }
+- { name: [lib32-xcb-util-renderutil,libxcb-render-util,xorg-xcb-render-util], setname: xcb-util-renderutil }
 
 # libs exceptions
 - { name: [xorg-pixman, xorg-libpixman, libpixman, pixman-static], setname: pixman }


### PR DESCRIPTION
Whenever possible, the rules I create here address all other repositories with similar orphaned metapackages.  for example, rather than just fix "xorg-xkeyboard-config" for ravenports, I created a rule that merged 5 orphaned xkeyboard-config ports.

Everything was straightforward except fontutil.  I detailed the issue in the commit message, but the synopsis is that a too-broad rule in section 88 converted xorg's font-util to "fonts:util" which is probably undesired.  The rule I added in section 16 merges *numerous* orphans to the existing "fonts:util" metapackage so at least they are all together, but you probably want to fix the original rule and move these to the "font-util" metapackage.