### PR TITLE
Update broken link on metapackage report page

### DIFF
--- a/templates/metapackage-report.html
+++ b/templates/metapackage-report.html
@@ -19,7 +19,7 @@
 	<li>Some packages may use incorrect versions (for instance, picking "next" version number which was not released yet when packaging a git snapshot, or using dates and commit hashes instead of version numbers).</li>
 </ul>
 
-<p>Repology uses a set of manually edited rules to resolve these cases. You may submit a change to the <a href="https://github.com/AMDmi3/repology/blob/master/rules.yaml">ruleset</a> directly or use this form to suggest an improbement to the ruleset. Please only use this for for problems which may be fixed by the ruleset (which are basically problems listed above).</p>
+<p>Repology uses a set of manually edited rules to resolve these cases. You may submit a change to the <a href="https://github.com/repology/repology/blob/master/docs/RULES.md">ruleset</a> directly or use this form to suggest an improbement to the ruleset. Please only use this for for problems which may be fixed by the ruleset (which are basically problems listed above).</p>
 
 {% if reports %}
 <h2>Current reports ({{ reports|length }})</h2>


### PR DESCRIPTION
Fix 404 link to absent rules.yaml file by linking to the rules page in the documentation.

Fixes #355  