### PR TITLE
[wip] dockerize build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM python:3.6
+
+WORKDIR /usr/src/app
+
+COPY . /usr/src/app
+VOLUME /usr/src/app
+
+# Get all system-level deps
+RUN apt update && \
+    apt install -y cmake librpm-dev pkg-config
+
+RUN pip install -r requirements.txt
+
+# Install libversion
+# and compile the python binding for it
+RUN wget -qO- https://github.com/repology/libversion/archive/2.2.0.tar.gz | tar -xzf- && \
+ ( cd libversion-2.2.0 && cmake . && make && make install ) && \
+ make
+
+ENTRYPOINT ./repology-app.py

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     volumes:
       - .:/usr/src/app
     environment:
-        REPOLOGY_CONFIG: repology.conf.docker
+        REPOLOGY_CONFIG: repology-docker.conf.default
     ports:
       - 5000:5000
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,28 @@
+version: '3'
+
+services:
+  www:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    working_dir: /usr/src/app
+    volumes:
+      - .:/usr/src/app
+    environment:
+        REPOLOGY_CONFIG: repology.conf.docker
+    ports:
+      - 5000:5000
+
+  database:
+    image: postgres
+    environment:
+      - POSTGRES_DB=repology
+      - POSTGRES_USER=repology
+      - POSTGRES_PASSWORD=repology
+    ports:
+      - 5432:5432
+
+networks:
+  default:
+    external:
+      name: repology

--- a/repology-app.py
+++ b/repology-app.py
@@ -29,4 +29,4 @@ if __name__ == '__main__':
         app.wsgi_app = ProfilerMiddleware(app.wsgi_app, restrictions=[30])
         app.run(debug=True)
     else:
-        app.run()
+        app.run(host='0.0.0.0')

--- a/repology-docker.conf.default
+++ b/repology-docker.conf.default
@@ -1,0 +1,125 @@
+#
+# Repology default configuration file
+#
+# These settings are used in web application and as defaults
+# for all command line utilities. You may override them in
+# repology.conf file in project root or in any custom file,
+# as long as you set path to it in REPOLOGY_CONF environment
+# variable
+
+############################################################################
+# COMMON SETTINGS
+############################################################################
+
+#
+# Postgresql database connect string
+#
+# Used by repology-update and repology-app
+# Overridable via --dsn command line arg
+#
+DSN = "dbname=repology user=repology password=repology host=repology_database_1"
+
+#
+# Directory to store repository data in
+#
+# Used in repology-update and repology-dump
+# Overridable via --statedir command line arg
+#
+STATE_DIR = "_state"
+
+#
+# Path to YAML file containing repository configuration
+#
+# Used by repology-update, repology-app, repology-dump
+# Overridable via --repos-path command line arg
+#
+REPOS_DIR = "repos.d"
+
+#
+# Path to YAML file containing package transformation rules
+#
+# Used by repology-update
+# Overridable via --rules-path command line arg
+#
+RULES_DIR = "rules.d"
+
+#
+# Array of repository names or tags to work with
+#
+# Used by repology-update and repology-dump
+# Overridable via free command line args
+#
+REPOSITORIES = ['production']
+
+############################################################################
+# UPDATE SETTINGS
+############################################################################
+
+#
+# Path to helpers directory
+#
+# Helpers are small programs or scripts used to parse repository
+# data in different formats which are hard to parse directly from
+# python
+#
+# Used by repology-update
+#
+HELPERS_DIR = "helpers"
+
+#
+# Path to tclsh
+#
+# tclsh is used to parse macports repository
+#
+# Used by repology-update
+#
+TCLSH = "tclsh"
+
+############################################################################
+# WEBAPP SETTINGS
+############################################################################
+
+#
+# Secret key for flask, see
+# http://flask.pocoo.org/docs/0.12/api/#flask.Flask.secret_key
+#
+# There's no default value, please set it to some random string
+#
+SECRET_KEY = 'abc'
+
+#
+# Enable webapp profiling
+#
+PROFILE = False
+
+#
+# Items per page
+#
+METAPACKAGES_PER_PAGE = 200
+MAINTAINERS_PER_PAGE = 500
+PROBLEMS_PER_PAGE = 500
+
+#
+# Max reports for metapackage
+#
+MAX_REPORTS = 20
+
+#
+# Address of repology.org to use in HTML links
+#
+REPOLOGY_HOME = 'https://repology.org'
+
+#
+# Path to DejaVuSans.ttf
+#
+# This is used to calculate SVG badge sizes
+#
+#BADGE_FONT = '/usr/local/share/fonts/dejavu/DejaVuSans.ttf'  # FreeBSD
+#BADGE_FONT = '/usr/share/fonts/truetype/ttf-dejavu/DejaVuSans.ttf'  # Ubuntu
+
+#
+# AFK times when reports cannot be processed, to be reported to users
+# array of strings in 'YYYY-MM-DD' (single date) or 'YYYY-MM-DD
+# YYYY-MM-DD' (date interval) format
+#
+STAFF_AFK = []

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+PyYAML
+requests
+
+flask
+pillow
+psycopg2
+
+lxml
+rubymarshal


### PR DESCRIPTION
This introduces a containerized build for repology, which effectively enables you to just use  `docker-compose` to build the entire stack.

It is currently in a working state, but documentation needs to be added on how to use it.

I'm opening up the PR now in hopes of soliciting feedback from @AMDmi3 and the community using repology so far. 