### PR TITLE
Merge pyqt4/pyqt5 into python:pyqt4/pyqt5

### DIFF
--- a/rules.d/70.global-python.yaml
+++ b/rules.d/70.global-python.yaml
@@ -80,6 +80,8 @@
     - pylint-plugin-utils
     - pypoppler
     - pyproj
+    - pyqt4
+    - pyqt5
     - pyserial
     - pytest
     - pytest-catchlog


### PR DESCRIPTION
Those are the same:

https://repology.org/metapackage/pyqt4
https://repology.org/metapackage/python:pyqt4

https://repology.org/metapackage/pyqt5
https://repology.org/metapackage/python:pyqt5

---

This is my first time contributing here and this is totally untested - so please let me know if something is wrong!