### PR TITLE
Update Fedora repos

### DIFF
--- a/repos.d/rpm/fedora.yaml
+++ b/repos.d/rpm/fedora.yaml
@@ -1,36 +1,6 @@
 ###########################################################################
 # Fedora
 ###########################################################################
-- name: fedora_25
-  type: repository
-  desc: Fedora 25
-  family: fedora
-  color: '294172'
-  sources:
-    - name: release
-      fetcher: Repodata
-      parser: Repodata
-      url: https://download.fedoraproject.org/pub/fedora/linux/releases/25/Everything/source/tree/
-      subrepo: release
-    - name: updates
-      fetcher: Repodata
-      parser: Repodata
-      url: https://download.fedoraproject.org/pub/fedora/linux/updates/25/SRPMS/
-      subrepo: updates
-  repolinks:
-    - desc: Fedora home
-      url: https://getfedora.org/
-    - desc: Fedora Packages Search
-      url: https://apps.fedoraproject.org/packages/
-    - desc: Fedora repository for package maintenance
-      url: https://src.fedoraproject.org/
-  packagelinks:
-    - desc: Package details on Fedora Packages
-      url: 'https://apps.fedoraproject.org/packages/{name}/overview'
-    - desc: Package details on Fedora Pagure
-      url: 'https://src.fedoraproject.org/rpms/{name}'
-  tags: [ all, production, fedora, rpm ]
-
 - name: fedora_26
   type: repository
   desc: Fedora 26
@@ -70,12 +40,42 @@
     - name: release
       fetcher: Repodata
       parser: Repodata
-      url: https://mirror.yandex.ru/fedora/linux/releases/27/Everything/source/tree/
+      url: https://download.fedoraproject.org/pub/fedora/linux/releases/27/Everything/source/tree/
       subrepo: release
     - name: updates
       fetcher: Repodata
       parser: Repodata
       url: https://download.fedoraproject.org/pub/fedora/linux/updates/27/SRPMS/
+      subrepo: updates
+  repolinks:
+    - desc: Fedora home
+      url: https://getfedora.org/
+    - desc: Fedora Packages Search
+      url: https://apps.fedoraproject.org/packages/
+    - desc: Fedora repository for package maintenance
+      url: https://src.fedoraproject.org/
+  packagelinks:
+    - desc: Package details on Fedora Packages
+      url: 'https://apps.fedoraproject.org/packages/{name}/overview'
+    - desc: Package details on Fedora Pagure
+      url: 'https://src.fedoraproject.org/rpms/{name}'
+  tags: [ all, production, fedora, rpm ]
+
+- name: fedora_28
+  type: repository
+  desc: Fedora 28
+  family: fedora
+  color: '294172'
+  sources:
+    - name: development
+      fetcher: Repodata
+      parser: Repodata
+      url: https://download.fedoraproject.org/pub/fedora/linux/development/28/Everything/source/tree/
+      subrepo: development
+    - name: updates
+      fetcher: Repodata
+      parser: Repodata
+      url: https://download.fedoraproject.org/pub/fedora/linux/updates/28/SRPMS/
       subrepo: updates
   repolinks:
     - desc: Fedora home


### PR DESCRIPTION
- Remove Fedora 25, which has reached end of life
- Add Fedora 28 development