### PR TITLE
metapackages.html: mark "Search" button as primary

### DIFF
--- a/repologyapp/templates/metapackages.html
+++ b/repologyapp/templates/metapackages.html
@@ -136,7 +136,7 @@ Metapackages
 			</div>
 			<div class="form-group">
 				<div class="col-sm-offset-2 col-sm-10">
-					<button type="submit" class="btn btn-default">Search</button>
+					<button type="submit" class="btn btn-primary">Search</button>
 					<a href="{{ url_for_self(bound=None) }}" class="btn btn-default">Clear</a>
 				</div>
 			</div>


### PR DESCRIPTION
This provides visual distinction between the "Search" and the "Cancel" buttons.