### PR TITLE
Link to Arch Linux packages search for the primary Arch Linux link

### DIFF
--- a/repos.d/arch/arch.yaml
+++ b/repos.d/arch/arch.yaml
@@ -20,6 +20,8 @@
       url: https://www.archlinux.org/packages/
   packagelinks:
     # note that there are only two git repos: "packages" and "community"; this is handled in repology/packageformatter.py
+    - desc: Package details on www.archlinux.org
+      url: 'https://www.archlinux.org/packages/?q={name}'
     - desc: Git repository
       url: 'https://git.archlinux.org/svntogit/{archrepo}.git/tree/trunk?h=packages/{archbase}'
     - desc: PKGBUILD


### PR DESCRIPTION
This page links to individual package pages,
which link to other useful links like bugs.