### PR TITLE
update entware repository link in news

### DIFF
--- a/repologyapp/templates/news.html
+++ b/repologyapp/templates/news.html
@@ -37,7 +37,7 @@
 <article>
 	<h3 id="2018-02-16">2018-02-16</h3>
 	<ul>
-		<li>Added <a href="{{ url_for('repository', repo='entware_ng') }}">Entware-ng</a> repository.</li>
+		<li>Added <a href="{{ url_for('repository', repo='entware') }}">Entware</a> repository.</li>
 		<li>Added newer antiX <a href="{{ url_for('repository', repo='antix_17') }}">antiX-17</a> repository.</li>
 		<li>Added <a href="{{ url_for('repository', repo='scoop') }}">Scoop</a> repository.</li>
 	</ul>

--- a/repologyapp/templates/news.html
+++ b/repologyapp/templates/news.html
@@ -37,7 +37,7 @@
 <article>
 	<h3 id="2018-02-16">2018-02-16</h3>
 	<ul>
-		<li>Added <a href="{{ url_for('repository', repo='entware') }}">Entware</a> repository.</li>
+		<li>Added <a href="{{ url_for('repository', repo='entware') }}">Entware-ng</a> repository.</li>
 		<li>Added newer antiX <a href="{{ url_for('repository', repo='antix_17') }}">antiX-17</a> repository.</li>
 		<li>Added <a href="{{ url_for('repository', repo='scoop') }}">Scoop</a> repository.</li>
 	</ul>


### PR DESCRIPTION
Not sure if rewriting history is ok.

At least the link should be fixed. Currently 404!

Related to https://github.com/repology/repology/pull/554.