### PR TITLE
Don't deobfuscate MacPorts maintainer emails

### DIFF
--- a/repology/parsers/parsers/macports.py
+++ b/repology/parsers/parsers/macports.py
@@ -61,9 +61,8 @@ class MacPortsParser(Parser):
                             # plain email
                             pkg.add_maintainers(maintainer)
                         elif ':' in maintainer:
-                            # foo.com:bar means bar@foo.com
-                            host, user = maintainer.split(':', 1)
-                            pkg.add_maintainers(user + '@' + host)
+                            # ignore, email is obfuscated
+                            pass
                         elif maintainer == 'openmaintainer':
                             # ignore, this is a flag that minor changes to a port
                             # are allowed without involving the maintainer


### PR DESCRIPTION
In https://github.com/macports/macports-ports/pull/2877#issuecomment-433511400, one of our maintainers wrote:
> Please don't post my email like that for robots to find! 😭

1275d6ec952cc661e54ad7f5dbc7db059888b58d ignores obfuscated addresses, so ignore them here too. See #651.