### PR TITLE
repos.d/deb: Add BunsenLabs Linux repository (Debian derivate)

### DIFF
--- a/repos.d/deb/bunsenlabs.yaml
+++ b/repos.d/deb/bunsenlabs.yaml
@@ -1,0 +1,86 @@
+###########################################################################
+# BunsenLabs
+###########################################################################
+- name: bunsenlabs_hydrogen
+  type: repository
+  desc: BunsenLabs Hydrogen
+  family: debuntu
+  color: f6b620
+  minpackages: 10
+  sources:
+    - name: [ 'bunsen-hydrogen/main' ]
+      fetcher: FileFetcher
+      parser: DebianSourcesParser
+      url: 'https://pkg.bunsenlabs.org/debian/dists/{source}/source/Sources.gz'
+      compression: gz
+      subrepo: '{source}'
+  repolinks:
+    - desc: BunsenLabs Repository Index
+      url: 'https://www.bunsenlabs.org/repoidx.html'
+  packagelinks:
+    - desc: 'Package details'
+      url: 'https://www.bunsenlabs.org/repoidx.html?k=name-description&v={name}'
+  tags: [ all, oldstable, bunsenlabs ]
+
+- name: bunsenlabs_helium
+  type: repository
+  desc: BunsenLabs Helium
+  family: debuntu
+  color: f6b620
+  minpackages: 10
+  sources:
+    - name: [ 'helium/main' ]
+      fetcher: FileFetcher
+      parser: DebianSourcesParser
+      url: 'https://pkg.bunsenlabs.org/debian/dists/{source}/source/Sources.gz'
+      compression: gz
+      subrepo: '{source}'
+  repolinks:
+    - desc: BunsenLabs Repository Index
+      url: 'https://www.bunsenlabs.org/repoidx.html'
+  packagelinks:
+    - desc: 'Package details'
+      url: 'https://www.bunsenlabs.org/repoidx.html?k=name-description&v={name}'
+  tags: [ all, stable, bunsenlabs ]
+
+- name: bunsenlabs_jessie_backports
+  type: repository
+  desc: BunsenLabs Hydrogen/Jessie Backports
+  family: debuntu
+  color: f6b620
+  minpackages: 1
+  sources:
+    - name: [ 'jessie-backports/main' ]
+      fetcher: FileFetcher
+      parser: DebianSourcesParser
+      url: 'https://pkg.bunsenlabs.org/debian/dists/{source}/source/Sources.gz'
+      compression: gz
+      subrepo: '{source}'
+  repolinks:
+    - desc: BunsenLabs Repository Index
+      url: 'https://www.bunsenlabs.org/repoidx.html'
+  packagelinks:
+    - desc: 'Package details'
+      url: 'https://www.bunsenlabs.org/repoidx.html?k=name-description&v={name}'
+  tags: [ all, oldstable, backports, bunsenlabs ]
+
+- name: bunsenlabs_stretch_backports
+  type: repository
+  desc: BunsenLabs Helium/Stretch Backports
+  family: debuntu
+  color: f6b620
+  minpackages: 1
+  sources:
+    - name: [ 'stretch-backports/main' ]
+      fetcher: FileFetcher
+      parser: DebianSourcesParser
+      url: 'https://pkg.bunsenlabs.org/debian/dists/{source}/source/Sources.gz'
+      compression: gz
+      subrepo: '{source}'
+  repolinks:
+    - desc: BunsenLabs Repository Index
+      url: 'https://www.bunsenlabs.org/repoidx.html'
+  packagelinks:
+    - desc: 'Package details'
+      url: 'https://www.bunsenlabs.org/repoidx.html?k=name-description&v={name}'
+  tags: [ all, stable, backports, bunsenlabs ]


### PR DESCRIPTION
Homepage: https://www.bunsenlabs.org
Census: https://wiki.debian.org/Derivatives/Census/BunsenLabs