### PR TITLE
nixos_stable: 18.09 -> 19.03

### DIFF
--- a/repos.d/nixos.yaml
+++ b/repos.d/nixos.yaml
@@ -21,7 +21,7 @@
       url: https://github.com/NixOS/nixpkgs
   packagelinks:
     - desc: Package source (release branch)  # XXX: branch name needs manual maintenance
-      url: 'https://github.com/NixOS/nixpkgs/blob/release-18.09/{posfile}#L{posline}'
+      url: 'https://github.com/NixOS/nixpkgs/blob/release-19.03/{posfile}#L{posline}'
     - desc: Package source (master branch, imprecise link)
       url: 'https://github.com/NixOS/nixpkgs/blob/master/{posfile}#L{posline}'
   tags: [ all, production, nix ]


### PR DESCRIPTION
Not offically released yet, but the 19.03 branches are already on Github, so the script should work