### PR TITLE
Update Termux metadata url

### DIFF
--- a/repos.d/termux.yaml
+++ b/repos.d/termux.yaml
@@ -11,7 +11,7 @@
     - name: packages.json
       fetcher: FileFetcher
       parser: TermuxJsonParser
-      url: https://termux.net/dists/stable/packages.json
+      url: https://dl.bintray.com/termux/metadata/repology/packages.json
   repolinks:
     - desc: Termux home
       url: https://termux.com/


### PR DESCRIPTION
Termux is switching to use bintray for package hosting.

The old repository at termux.net will remain in maintenance mode for now, but active development happens at bintray.