### PR TITLE
Use the `next_page` metadata from crates.io

### DIFF
--- a/repology/fetchers/fetchers/cratesio.py
+++ b/repology/fetchers/fetchers/cratesio.py
@@ -33,7 +33,7 @@ class CratesIOFetcher(ScratchDirFetcher):
 
     def _do_fetch(self, statedir: AtomicDir, persdata: PersistentData, logger: Logger) -> bool:
         numpage = 1
-        query ='?per_page={}&sort=alpha'.format(self.per_page)
+        query = '?per_page={}&sort=alpha'.format(self.per_page)
         while query:
             url = self.url + query
             logger.log('getting ' + url)

--- a/repology/fetchers/fetchers/cratesio.py
+++ b/repology/fetchers/fetchers/cratesio.py
@@ -33,8 +33,8 @@ class CratesIOFetcher(ScratchDirFetcher):
 
     def _do_fetch(self, statedir: AtomicDir, persdata: PersistentData, logger: Logger) -> bool:
         numpage = 1
-        while True:
-            url = self.url + '?page={}&per_page={}&sort=alpha'.format(numpage, self.per_page)
+        url = self.url + '?per_page={}&sort=alpha'.format(self.per_page)
+        while url:
             logger.log('getting ' + url)
 
             text = self.do_http(url).text
@@ -44,8 +44,9 @@ class CratesIOFetcher(ScratchDirFetcher):
                 os.fsync(pagefile.fileno())
 
             # parse next page
-            if not json.loads(text)['crates']:
-                logger.log('last page detected')
-                return True
+            url = json.loads(text)['meta']['next_page']
 
             numpage += 1
+
+        logger.log('last page detected')
+        return True

--- a/repology/fetchers/fetchers/cratesio.py
+++ b/repology/fetchers/fetchers/cratesio.py
@@ -33,8 +33,9 @@ class CratesIOFetcher(ScratchDirFetcher):
 
     def _do_fetch(self, statedir: AtomicDir, persdata: PersistentData, logger: Logger) -> bool:
         numpage = 1
-        url = self.url + '?per_page={}&sort=alpha'.format(self.per_page)
-        while url:
+        query ='?per_page={}&sort=alpha'.format(self.per_page)
+        while query:
+            url = self.url + query
             logger.log('getting ' + url)
 
             text = self.do_http(url).text
@@ -44,7 +45,7 @@ class CratesIOFetcher(ScratchDirFetcher):
                 os.fsync(pagefile.fileno())
 
             # parse next page
-            url = json.loads(text)['meta']['next_page']
+            query = json.loads(text)['meta']['next_page']
 
             numpage += 1
 


### PR DESCRIPTION
crates.io will be deprecating its numbered pagination in the near
future. In order to help clients migrate to the new pagination API, a
`next_page` and `prev_page` field is included in the response metadata,
unless you're on the first/last page.

Currently this should not result in any change in functionality (the
values in `next_page` will equal what was being hit before), but once
the new pagination system is in place, this field will switch to using
it, meaning Repology will be unaffected when the old pagination is
eventually removed.

I was not able to test this change locally, as there doesn't seem to be
a way to just run a single fetcher without also having a database set
up, installing C libraries that aren't published to any package manager
that I could find, etc.

Thanks for setting a useful user-agent header so I can reach out with
this PR instead of just breaking your app